### PR TITLE
Fix pingScan portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PingScan
-You can scan your network to recognisse the IPs that respond to ping.
+PingScan lets you scan your network to recognize the IPs that respond to ping.
 
-Run `python pingScan.py --base 192.168` to specify a different network prefix.
+Run `python3 pingScan.py --base 192.168` to specify a different network prefix.
 
 * Important: This program should be executed with administrator privileges.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # PingScan
 You can scan your network to recognisse the IPs that respond to ping.
 
+Run `python pingScan.py --base 192.168` to specify a different network prefix.
+
 * Important: This program should be executed with administrator privileges.

--- a/pingScan.py
+++ b/pingScan.py
@@ -1,5 +1,7 @@
 import subprocess
 import threading
+import platform
+import argparse
 
 BASE = "192.168"
 OUTPUT_FILE = "ping.txt"
@@ -8,27 +10,35 @@ lock = threading.Lock()
 
 def ping_ip(ip):
     try:
-        output = subprocess.check_output("ping -n 1 -w 500 " + ip, shell=True).decode("utf-8", errors="ignore")
-        
-        # CAMBIAR LA SIGUIENTE LÍNEA CON EL MENSAJE CORRECTO DE TU SISTEMA
-        success_msg = "Respuesta desde"  # Por ejemplo: "Reply from"
-        
-        if success_msg in output:
+        if platform.system() == "Windows":
+            cmd = ["ping", "-n", "1", "-w", "500", ip]
+        else:
+            cmd = ["ping", "-c", "1", "-W", "1", ip]
+
+        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        if result.returncode == 0:
             with lock:
                 with open(OUTPUT_FILE, 'a') as f:
                     f.write(ip + '\n')
                 print(f"{ip} respondió")
-    except subprocess.CalledProcessError:
+    except Exception:
         pass
 
 def main():
+    parser = argparse.ArgumentParser(description="Scan network for responsive IPs")
+    parser.add_argument('-b', '--base', default=BASE, help='Base network prefix, e.g. 192.168')
+    args = parser.parse_args()
+
+    base = args.base
+
     with open(OUTPUT_FILE, 'w') as f:
         f.write('')
     threads = []
 
     for i in range(256):
         for j in range(256):
-            ip = f"{BASE}.{i}.{j}"
+            ip = f"{base}.{i}.{j}"
             t = threading.Thread(target=ping_ip, args=(ip,))
             t.start()
             threads.append(t)


### PR DESCRIPTION
## Summary
- ensure README has a trailing newline
- make `pingScan.py` use platform-specific ping parameters and rely on the exit code instead of parsing localized text
- add argparse argument for network base

## Testing
- `python3 -m py_compile pingScan.py`
- `python3 pingScan.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6847c84b9d44832c8488f8161aaf73a5